### PR TITLE
fix(frontend): fixes height issue connect wallet button

### DIFF
--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-    "extends": ["next/core-web-vitals", "plugin:prettier/recommended"]
+    "extends": ["next/core-web-vitals", "plugin:prettier/recommended"],
+    "rules": { "prettier/prettier": ["error", { "endOfLine": "auto" }] }
 }

--- a/packages/frontend/src/components/connect-button/styles.module.css
+++ b/packages/frontend/src/components/connect-button/styles.module.css
@@ -3,17 +3,17 @@
 }
 
 .connectButton {
-    @apply h-9 rounded-lg;
+    @apply h-10 rounded-lg;
 }
 
 .wrapper {
-    @apply flex gap-3;
+    @apply flex items-center gap-3;
 }
 
 .networkWrapper {
     @apply bg-white
-        w-9
-        h-9
+        w-10
+        h-10
         rounded-md
         flex
         gap-3


### PR DESCRIPTION
Aligns the height of the Connect button and network icon with the rest of the menu items. Typography remains unchanged as it was already uniform.
